### PR TITLE
Adjust the API to Automatically Detect and Use the Server Address

### DIFF
--- a/frontend/src/components/eventForm.tsx
+++ b/frontend/src/components/eventForm.tsx
@@ -86,7 +86,7 @@ const EventForm: React.FC<EventFormProps> = ({ event, onSave, onClose, isViewMod
                 />
               </div>
               <div className="col-span-6 sm:col-span-3">
-                <label htmlFor="description" className="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                <label htmlFor="description" className="block mb-2 text-sm font-medium text-gray-900">
                   Description
                 </label>
                 <input type="text" name="description" id="description"

--- a/frontend/src/components/eventTable.tsx
+++ b/frontend/src/components/eventTable.tsx
@@ -86,7 +86,7 @@ const EventTable: React.FC = () => {
   }
 
   return (
-    <div className="relative overflow-x-auto shadow-md sm:rounded-lg">
+    <div className="relative overflow-x-auto">
       <div className="flex justify-between items-center mb-4">
         <div className="flex space-x-4">
           <form onSubmit={handleSearch} className="flex space-x-2">
@@ -106,7 +106,7 @@ const EventTable: React.FC = () => {
               className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" data-testid="btnSearch"
             >Search</button>
             <button onClick={handleCreateNewEvent} className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                New Event
+                New event
             </button>
           </form>
           

--- a/frontend/src/services/eventServices.tsx
+++ b/frontend/src/services/eventServices.tsx
@@ -4,7 +4,7 @@ import { EventModel } from "../models/eventModel";
 import { EventError } from "../models/eventError";
 
 export const apiClient = axios.create({
-  baseURL: "http://localhost:5000/api/v1",
+  baseURL: window.location.href + "/api/v1",
   headers: {
     "Content-Type": "application/json",
   },

--- a/frontend/src/services/eventServices.tsx
+++ b/frontend/src/services/eventServices.tsx
@@ -4,7 +4,7 @@ import { EventModel } from "../models/eventModel";
 import { EventError } from "../models/eventError";
 
 export const apiClient = axios.create({
-  baseURL: window.location.href + "/api/v1",
+  baseURL: window.location.href + "api/v1",
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
Adjust the API to automatically detect and use the server address and port instead of being fixed to localhost and a specific port.

To enhance the flexibility of the application, allowing it to operate seamlessly in different environments without requiring manual modifications. This adjustment ensures that the API can dynamically adapt to changes in its deployment environment, improving its robustness and ease of deployment.

close #71 